### PR TITLE
Pagination label style fixes

### DIFF
--- a/src/stylesheet.css
+++ b/src/stylesheet.css
@@ -9,8 +9,11 @@
 .pagination-item {
   margin-top: 2.5em;
 }
-.pagination-item a {
+.pagination-item a,
+.pagination-item a:hover {
   text-decoration: none;
+}
+.pagination-item a {
   color: currentColor;
 }
 .pagination-item a:hover .pagination-item-title {
@@ -29,7 +32,6 @@
   opacity: 1;
 }
 .pagination-item-label {
-  margin-bottom: 0.35em;
   font-size: 0.8em;
 }
 .pagination-item-label > * {


### PR DESCRIPTION
- Prevents pagination labels from displaying an underline on `:hover`. This was not an issue for themes that do not specify a :hover style for links (like `vue.css`), but it was for other themes that do specify `text-decoration: underline` on `:hover`.
- Removed additional spacing between pagination label and title.