### PR TITLE
Fix: Parse alink url and unicode character error.

### DIFF
--- a/src/pagination.js
+++ b/src/pagination.js
@@ -25,7 +25,7 @@ function isALinkTo (path, element) {
   if (arguments.length === 1) {
     return (element) => isALinkTo(path, element)
   }
-  return element.getAttribute('href').split('?')[0] === `#${path}`
+  return decodeURI(element.getAttribute('href').split('#')[1]) === decodeURI(path)
 }
 
 

--- a/src/pagination.js
+++ b/src/pagination.js
@@ -25,7 +25,7 @@ function isALinkTo (path, element) {
   if (arguments.length === 1) {
     return (element) => isALinkTo(path, element)
   }
-  return decodeURI(element.getAttribute('href').split('#')[1]) === decodeURI(path)
+  return decodeURIComponent(element.getAttribute('href').split('?')[0]) === decodeURIComponent(`#${path}`)
 }
 
 


### PR DESCRIPTION
I use the latest docsify and found this plugin is not working correctly. The url in side bar is like `http://localhost:3000/#/aaa/bbb/...`.

I change the parsing method in `isALinkTo` function. And add `decodeURI` support when there is unicode character in url.