### PR TITLE
Add the crossChapter option

### DIFF
--- a/example/_sidebar.md
+++ b/example/_sidebar.md
@@ -2,3 +2,11 @@
 - [Foo](foo.md#section-3)
 - [Bar A Long Long Long Title](bar.md)
 - [Baz](baz.md)
+- Chapter 2
+  - [Foo](foo.md)
+  - [Bar](bar.md)
+  - [Baz](baz.md)
+- Chapter 3
+  - [Foo](foo.md)
+  - [Bar](bar.md)
+  - [Baz](baz.md)

--- a/example/index.html
+++ b/example/index.html
@@ -38,6 +38,7 @@
       pagination: {
         previousText: '上一章节',
         nextText: '下一章节',
+        crossChapter: true,
       }
     }
   </script>

--- a/readme.md
+++ b/readme.md
@@ -23,6 +23,7 @@
     pagination: {
       previousText: '上一章节',
       nextText: '下一章节',
+      crossChapter: true
     },
   }
   ```
@@ -37,6 +38,11 @@
 * **Default:** ``'NEXT'``
 * **Type:** ``String``
 * **Description:** The text of next label.
+
+### pagination.crossChapter
+* **Default:** `false`
+* **Type:** ``Boolean``
+* **Description:** Allow navigation to previous/next chapter.
 
 ## Example
 - [example/index.html](example/index.html)


### PR DESCRIPTION
As requested in issue #12 this PR provides a new configuration option `crossChapter` in order to allow the previous / next links to work through the different chapters and not only the current one open.

| Before | After |
|-|-|
| ![Screenshot from 2019-04-12 14-20-14](https://user-images.githubusercontent.com/1302282/56012094-332d5b00-5d2e-11e9-98df-6c7aa55d90f6.png) | ![Screenshot from 2019-04-12 14-19-49](https://user-images.githubusercontent.com/1302282/56012101-39bbd280-5d2e-11e9-95c3-0e43bf4e6bf7.png) |

Tell me what you think.
Basically in the code I use the `all` array instead of the `group`.

_(as a side note, if this PR is merged or approved I'll take some extra time to try to include the chapter name in the link when we go to the previous/next one.)_

----

close #12 