### PR TITLE
Implement support for chapter names in links

### DIFF
--- a/example/_sidebar.md
+++ b/example/_sidebar.md
@@ -1,12 +1,18 @@
-- [Home](/)
-- [Foo](foo.md#section-3)
-- [Bar A Long Long Long Title](bar.md)
-- [Baz](baz.md)
+- Chapter 1
+
+    - [Home](/)
+    - [Foo](foo.md#section-3)
+    - [Bar A Long Long Long Title](bar.md)
+    - [Baz](baz.md)
+
 - Chapter 2
-  - [Foo](foo.md)
-  - [Bar](bar.md)
-  - [Baz](baz.md)
+
+    - [Foo](foo.md)
+    - [Bar](bar.md)
+    - [Baz](baz.md)
+
 - Chapter 3
-  - [Foo](foo.md)
-  - [Bar](bar.md)
-  - [Baz](baz.md)
+
+    - [Foo](foo.md)
+    - [Bar](bar.md)
+    - [Baz](baz.md)

--- a/example/index.html
+++ b/example/index.html
@@ -39,6 +39,7 @@
         previousText: '上一章节',
         nextText: '下一章节',
         crossChapter: true,
+        crossChapterText: true,
       }
     }
   </script>

--- a/readme.md
+++ b/readme.md
@@ -23,7 +23,8 @@
     pagination: {
       previousText: '上一章节',
       nextText: '下一章节',
-      crossChapter: true
+      crossChapter: true,
+      crossChapterText: true,
     },
   }
   ```
@@ -43,6 +44,11 @@
 * **Default:** `false`
 * **Type:** ``Boolean``
 * **Description:** Allow navigation to previous/next chapter.
+
+### pagination.crossChapterText
+* **Default:** `false`
+* **Type:** ``Boolean``
+* **Description:** Display chapter name.
 
 ## Example
 - [example/index.html](example/index.html)

--- a/src/pagination.js
+++ b/src/pagination.js
@@ -10,6 +10,7 @@ const DEFAULT_OPTIONS = {
   previousText: 'PREVIOUS',
   nextText: 'NEXT',
   crossChapter: false,
+  crossChapterText: false
 }
 const CONTAINER_CLASSNAME = 'docsify-pagination-container'
 
@@ -38,11 +39,11 @@ function isALinkTo (path, element) {
  * core renderer
  */
 class Link {
-  constructor (element) {
+  constructor (element, showChapterName = false) {
     if (!element) {
       return
     }
-    this.chapter = findChapter(element)
+    this.chapter = showChapterName && findChapter(element)
     this.hyperlink = findHyperlink(element)
   }
   toJSON () {
@@ -52,7 +53,7 @@ class Link {
     return {
       name: this.hyperlink.innerText,
       href: this.hyperlink.getAttribute('href'),
-      chapterName: this.chapter.innerText
+      chapterName: this.chapter && this.chapter.innerText || ''
     }
   }
 }

--- a/src/pagination.js
+++ b/src/pagination.js
@@ -10,7 +10,7 @@ const DEFAULT_OPTIONS = {
   previousText: 'PREVIOUS',
   nextText: 'NEXT',
   crossChapter: false,
-  crossChapterText: true
+  crossChapterText: false,
 }
 const CONTAINER_CLASSNAME = 'docsify-pagination-container'
 

--- a/src/pagination.js
+++ b/src/pagination.js
@@ -53,7 +53,7 @@ class Link {
     return {
       name: this.hyperlink.innerText,
       href: this.hyperlink.getAttribute('href'),
-      chapterName: this.chapter && this.chapter.innerText
+      chapterName: this.chapter && this.chapter.innerText || ''
     }
   }
 }

--- a/src/pagination.js
+++ b/src/pagination.js
@@ -39,11 +39,11 @@ function isALinkTo (path, element) {
  * core renderer
  */
 class Link {
-  constructor (element, showChapterName = false) {
+  constructor (element) {
     if (!element) {
       return
     }
-    this.chapter = showChapterName && findChapter(element)
+    this.chapter = findChapter(element)
     this.hyperlink = findHyperlink(element)
   }
   toJSON () {
@@ -53,7 +53,7 @@ class Link {
     return {
       name: this.hyperlink.innerText,
       href: this.hyperlink.getAttribute('href'),
-      chapterName: this.chapter && this.chapter.innerText || ''
+      chapterName: this.chapter && this.chapter.innerText
     }
   }
 }
@@ -89,6 +89,12 @@ const template = {
   },
 
   inner (data, options) {
+    const prevChapterSubtitle = data.prev &&
+      `<div class="pagination-item-subtitle">${data.prev.chapterName}</div>`;
+
+    const nextChapterSubtitle = data.next &&
+      `<div class="pagination-item-subtitle">${data.next.chapterName}</div>`
+
     return [
       data.prev && `
         <div class="pagination-item pagination-item--previous">
@@ -100,8 +106,9 @@ const template = {
               <span>${options.previousText}</span>
             </div>
             <div class="pagination-item-title">${data.prev.name}</div>
-            <div class="pagination-item-subtitle">${data.prev.chapterName}</div>
-          </a>
+      `,
+      data.prev && options.crossChapterText && `<div class="pagination-item-subtitle">${data.prev.chapterName}</div>`,
+      data.prev && `</a>
         </div>
       `,
       data.next && `
@@ -114,8 +121,9 @@ const template = {
               </svg>
             </div>
             <div class="pagination-item-title">${data.next.name}</div>
-            <div class="pagination-item-subtitle">${data.next.chapterName}</div>
-          </a>
+      `,
+      data.next && options.crossChapterText && `<div class="pagination-item-subtitle">${data.next.chapterName}</div>`,
+      data.next && `</a>
         </div>
       `
     ].filter(Boolean).join('')

--- a/src/pagination.js
+++ b/src/pagination.js
@@ -19,6 +19,10 @@ const CONTAINER_CLASSNAME = 'docsify-pagination-container'
 function toArray (elements) {
   return Array.prototype.slice.call(elements)
 }
+function findChapter (element) {
+  const container = closest(element, 'div > ul > li')
+  return query('p', container)
+}
 function findHyperlink (element) {
   return element.href ? element : query('a', element)
 }
@@ -38,6 +42,7 @@ class Link {
     if (!element) {
       return
     }
+    this.chapter = findChapter(element)
     this.hyperlink = findHyperlink(element)
   }
   toJSON () {
@@ -47,6 +52,7 @@ class Link {
     return {
       name: this.hyperlink.innerText,
       href: this.hyperlink.getAttribute('href'),
+      chapterName: this.chapter.innerText
     }
   }
 }
@@ -93,6 +99,7 @@ const template = {
               <span>${options.previousText}</span>
             </div>
             <div class="pagination-item-title">${data.prev.name}</div>
+            <div class="pagination-item-subtitle">${data.prev.chapterName}</div>
           </a>
         </div>
       `,
@@ -106,6 +113,7 @@ const template = {
               </svg>
             </div>
             <div class="pagination-item-title">${data.next.name}</div>
+            <div class="pagination-item-subtitle">${data.next.chapterName}</div>
           </a>
         </div>
       `

--- a/src/pagination.js
+++ b/src/pagination.js
@@ -10,7 +10,7 @@ const DEFAULT_OPTIONS = {
   previousText: 'PREVIOUS',
   nextText: 'NEXT',
   crossChapter: false,
-  crossChapterText: false
+  crossChapterText: true
 }
 const CONTAINER_CLASSNAME = 'docsify-pagination-container'
 

--- a/src/pagination.js
+++ b/src/pagination.js
@@ -89,12 +89,6 @@ const template = {
   },
 
   inner (data, options) {
-    const prevChapterSubtitle = data.prev &&
-      `<div class="pagination-item-subtitle">${data.prev.chapterName}</div>`;
-
-    const nextChapterSubtitle = data.next &&
-      `<div class="pagination-item-subtitle">${data.next.chapterName}</div>`
-
     return [
       data.prev && `
         <div class="pagination-item pagination-item--previous">

--- a/src/stylesheet.css
+++ b/src/stylesheet.css
@@ -20,7 +20,8 @@
   text-decoration: underline;
 }
 .pagination-item:not(:last-child) a .pagination-item-label,
-.pagination-item:not(:last-child) a .pagination-item-title {
+.pagination-item:not(:last-child) a .pagination-item-title,
+.pagination-item:not(:last-child) a .pagination-item-subtitle {
   opacity: 0.3;
   transition: all 200ms;
 }
@@ -58,4 +59,8 @@
 }
 .pagination-item-title {
   font-size: 1.6em;
+}
+.pagination-item-subtitle {
+  text-transform: uppercase;
+  opacity: 0.3;
 }


### PR DESCRIPTION
This change expands upon the addition of cross-chapter links implemented by https://github.com/imyelo/docsify-pagination/pull/14.

Specifically, a new `crossChapterText` flag has been added to provide the option for consumers to display the chapter name in the next/prev links as added context.

## Demo (After)
<img width="1362" alt="image" src="https://user-images.githubusercontent.com/14018477/72024228-c649e180-3229-11ea-84ad-674a6321d21f.png">

