### PR TITLE
fix: change the CSS selector to support mergeNavbar option

### DIFF
--- a/src/pagination.js
+++ b/src/pagination.js
@@ -68,7 +68,7 @@ function pagination (vm, { crossChapter, routerMode }) {
     const path = routerMode === ROUTER_MODE.HISTORY ?
       vm.route.path :
       `#${vm.route.path}`
-    const all = toArray(query.all('.sidebar li a')).filter((element) => !matches(element, '.section-link'))
+    const all = toArray(query.all('.sidebar-nav li a')).filter((element) => !matches(element, '.section-link'))
     const active = all.find(isALinkTo(path))
     const group = toArray((closest(active, 'ul') || {}).children)
       .filter((element) => element.tagName.toUpperCase() === 'LI')


### PR DESCRIPTION
In order to make it select right place when mergeNavbar option is true and you view with small width screen. Just like #27

当docsify的小屏模式合并导航栏选项为 true时，原有选择器将会错误的选择到合并进来的导航栏。因此我修改了css选择器选择的类的范围

from '.sidebar li a' to '.sidebar-nav li a'

![image](https://user-images.githubusercontent.com/34450149/135062377-3edc5a0d-e800-4fbe-924b-579bd48b815d.png)
